### PR TITLE
Updated button when there's not an active target

### DIFF
--- a/src/components/Button/index.jsx
+++ b/src/components/Button/index.jsx
@@ -5,15 +5,24 @@ import { Link } from 'react-router-dom';
 import img_foward from '../../assets/images/button/button-foward.svg';
 
 function Button(props){
-    return(
-        <Link 
-            className={`page__button --centralized-text --light-text --root-${props.root}`}
-            to={props.target === undefined ? '/#' : `/${props.target}`}
-        > 
-            <span>{props.text.toUpperCase()}</span>
-            {props.root !== 'post' ? '' : <img className="page__button-foward" src={img_foward} alt="Foward" />}
-        </Link>
-    );
+    if(props.target === undefined){
+        return(
+            <div className={`page__button --centralized-text --light-text --root-${props.root}`}> 
+                <span>{props.text.toUpperCase()}</span>
+                {props.root !== 'post' ? '' : <img className="page__button-foward" src={img_foward} alt="Foward" />}
+            </div>
+        );
+    }else{
+        return(
+            <Link 
+                className={`page__button --centralized-text --light-text --root-${props.root}`}
+                to={`/${props.target}`}
+            > 
+                <span>{props.text.toUpperCase()}</span>
+                {props.root !== 'post' ? '' : <img className="page__button-foward" src={img_foward} alt="Foward" />}
+            </Link>
+        );
+    }
 }
 
 export default Button;


### PR DESCRIPTION
## Problems  

1. Clicking a `Button` without an active `target` logged this message `Warning: Hash history cannot PUSH the same path; a new entry will not be added to the history stack`.

## Fix

1. Introduced a condtional statement making this `Button` a `<div>` or a `<Link>`.