### PR TITLE
Updated LikeButton support capability

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -1,13 +1,19 @@
-export const likeAItem = (item) => {
+export const likeAItem = (itemID,itemType) => {
     return {
         type: 'LIKE_A_ITEM',
-        item
+        item: {
+            itemID,
+            itemType
+        }
     };
 };
 
-export const deslikeAItem = (item) => {
+export const deslikeAItem = (itemID,itemType) => {
     return {
         type: 'DESLIKE_A_ITEM',
-        item
+        item: {
+            itemID,
+            itemType
+        }
     };
 };

--- a/src/components/LikeButton/index.jsx
+++ b/src/components/LikeButton/index.jsx
@@ -23,9 +23,9 @@ function LikeButton(props){
     
     const likeHandler = () => {
         if(findInArray(likedItems,props.toBeLiked) === false){
-            dispatch(likeAItem(props.toBeLiked));
+            dispatch(likeAItem(props.toBeLiked,props.itemType));
         }else{
-            dispatch(deslikeAItem(props.toBeLiked));
+            dispatch(deslikeAItem(props.toBeLiked,props.itemType));
         }
         setIsLiked(findInArray(likedItems,props.toBeLiked));
         window.sessionStorage.setItem("likedItems", JSON.stringify(likedItems));

--- a/src/components/ProductCard/index.jsx
+++ b/src/components/ProductCard/index.jsx
@@ -19,7 +19,10 @@ function ProductCard(props){
                 className="product-card__banner"
                 style={{backgroundImage: `url(${product.media.bannerURL})`}}
             >
-                <LikeButton toBeLiked={product.ID} />
+                <LikeButton 
+                    toBeLiked={product.ID}
+                    itemType="product"
+                />
             </div>
             <p className="product-card__title --dark-text">{product.info.title}</p>
             <p className="product-card__description --grey-text">{product.info.description === '' ? '\u00A0' : product.info.description}</p>

--- a/src/reducers/likeButtonReducer.js
+++ b/src/reducers/likeButtonReducer.js
@@ -4,14 +4,14 @@ const likeButtonReducer = (state = JSON.parse(window.sessionStorage.getItem("lik
     switch(action.type){
         case 'LIKE_A_ITEM':
             let likedList = state;
-
-            if(findInArray(state,action.item) === false){
-                likedList.push(action.item);
+            
+            if(findInArray(state,action.item.itemID) === false){
+                likedList.push(action.item.itemID);
             }
             return state = likedList;
 
         case 'DESLIKE_A_ITEM':
-            return state = filterInArray(state,action.item);
+            return state = filterInArray(state,action.item.itemID);
         
         default:
             return state;


### PR DESCRIPTION
## Problems  

1. Even though the `LikeButton`was designed to only  be used for products, the current design prevented it to be used one different types of items.

## Fix

1. Added `itemType` prop to the `LikeButton` component and to the Redux flow, which in the future will help sort out the ìtemID` by type.