### PR TITLE
Fixed redirect bug when userId wasn't stored

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -49,7 +49,8 @@ const Navbar = () => {
                             imageAlt='Search'
                         />
                     </NavbarLink>
-                    <NavbarLink redirector={`user?userId=${window.sessionStorage.getItem('loggedUserId')}`}>
+                    <NavbarLink redirector={`user${window.sessionStorage.getItem('loggedUserId') === null ? 
+                    '' : `?userId=${window.sessionStorage.getItem('loggedUserId')}`}`}>
                         <NavbarImage 
                             imageURL={img_profile}
                             imageAlt='Profile'


### PR DESCRIPTION
## Problems  

1. Bug where `Profile` button from `Navbar`  redirected to a `null` id'ed page when `loggedUserId` from `sessionStorage` didn't exist.

## Fix

1. Fixed at 6fdb545.