### PR TITLE
Introduced back-end API at Podcasts & Podcast pages

### DIFF
--- a/src/assets/sass/views/_page.scss
+++ b/src/assets/sass/views/_page.scss
@@ -220,7 +220,12 @@
             display: flex;
             flex-direction: row;
             width: 100%;
-
+            & .page__redirector-text{
+                margin: 1rem 0 0 0;
+                height: 1.1rem;
+                text-overflow: ellipsis;
+                overflow: hidden;
+            }
             & .page__redirector-banner{
                 display: flex;
                 background-size: 8rem 5rem;
@@ -441,6 +446,11 @@
                 &:hover .--title-info{
                     border-color: #73A8A0;
                 }
+                & .page__redirector-text{
+                    width: 85%;
+                    height: 2.6vh;
+                    margin: 1.2vh 0 0 0;
+                }
                 & .page__redirector-info{
                     display: flex;
                     flex-direction: column;
@@ -450,7 +460,7 @@
                     display: flex;
                     background-size: 30vh 20vh;
                     margin: 0 0 0 auto;
-                    width: 30vh;
+                    width: 37vh;
                     height: 20vh;
                 }
             }

--- a/src/views/Podcast.jsx
+++ b/src/views/Podcast.jsx
@@ -1,5 +1,11 @@
-import React from 'react';
-import {Redirect} from 'react-router-dom';
+import React, {
+    useEffect,
+    useState
+}from 'react';
+import {
+    Link,
+    Redirect
+} from 'react-router-dom';
 
 //Component
 import {
@@ -10,38 +16,54 @@ import {
 } from '../components';
 
 //Services
-import {API} from '../services/mockData';
-import {
-    getCurrentPageID,
-    getCurrentPageType,
-    filterOverall
-} from '../services';
+import {getCurrentPageID} from '../services';
 
 export const Podcast = () => {
-    const podcast = filterOverall(getCurrentPageID(),'podcast',API);
+    const [podcast,setPodcast] = useState('');
+    const [isLoading,setIsLoading] = useState(true);
 
-    if(podcast !== -1 && podcast === filterOverall(getCurrentPageID(),getCurrentPageType(),API)){
+    useEffect(() => {
+        fetch(`${process.env.REACT_APP_BACK_END_HOST}/api/podcasts/${getCurrentPageID()}`, {
+            method: 'GET'
+        })
+        .then(response => {
+            return response.json();
+        })
+        .then(data => {
+            if(data.success !== true){
+                setPodcast(-1);
+            }else{
+                setIsLoading(false);
+                setPodcast(data.podcasts);
+            }
+        })
+    },[]);
+
+    if(podcast !== -1 && getCurrentPageID() !== null){
         return(
             <React.Fragment>
                 <header>
                     <Navbar />
                 </header>
                 <main>
-                    <section className="page">
+                    <section className={isLoading ? "page --loading" : "page"}>
                         <Post>
                             <img 
                                 className="page__post-banner"
-                                src={podcast.media.bannerURL} 
-                                alt={podcast.info.name}  
+                                src={`${process.env.REACT_APP_BLOB_HOST}/jpeg/podcast/bg-${getCurrentPageID()}.jpg`} 
+                                alt={podcast.podcast_title ? podcast.podcast_title : 'Loading'}  
                             />
                             <div className="page__podcast --fade-up">
                                 <AudioPlayer>
-                                    <AudioPlayerButton audioURL={podcast.media.audioURL} />
+                                    <AudioPlayerButton audioURL={`${process.env.REACT_APP_BLOB_HOST}/mp3/podcasts/media-${getCurrentPageID()}.mp3`} />
                                 </AudioPlayer>      
                             </div>
-                            <p className="page__post-title --centralized-text">{podcast.info.podcastName}</p>
+                            <p className="page__post-title --centralized-text">{podcast.podcast_title ? podcast.podcast_title : 'Loading'}</p>
                             <div className="page__post-info">
-                                    <span className="page__post-onwership --grey-text --bottom-thin-borders">{podcast.info.onwership.username} #{podcast.info.onwership.userID}</span>
+                                    <Link 
+                                        to={`/user/${podcast.podcast_author}`}
+                                        className="page__post-onwership --grey-text --bottom-thin-borders">{podcast.podcast_author ? podcast.podcast_author : 'Loading'} #{getCurrentPageID()}
+                                    </Link>
                             </div>
                         </Post>
                     </section>

--- a/src/views/Podcasts.jsx
+++ b/src/views/Podcasts.jsx
@@ -1,4 +1,8 @@
-import React from 'react';
+import React, {
+    useState,
+    useEffect
+}
+from 'react';
 
 //Component
 import {
@@ -7,15 +11,27 @@ import {
     Redirector,
     RedirectorInfo,
     RedirectorText,
-    RedirectorBanner
+    RedirectorBanner,
+    Loader
 } from '../components';
 
-//Services
-import {API} from '../services/mockData';
-import {filterByType} from '../services';
 
 const Podcasts = () => {
-    const posts = filterByType('podcast',API);
+    const [podcasts,setPodcasts] = useState([]);
+    const [isLoading,setIsLoading] = useState(true);
+
+    useEffect(() => {
+        fetch(`${process.env.REACT_APP_BACK_END_HOST}/api/podcasts`, {
+            method: 'GET'
+        })
+        .then(response => {
+            return response.json();
+        })
+        .then(data => {
+            setIsLoading(false);
+            setPodcasts(data.podcasts);
+        })
+    },[]);
 
     return(
         <React.Fragment>
@@ -25,31 +41,32 @@ const Podcasts = () => {
             <main>
                 <section className="page">
                     <p className="page__place-holder">Podcasts</p>
+                    <Loader isLoading={isLoading} />
                     <Post>
-                        {posts.map((element,index) => {
+                        {podcasts.map((element,index) => {
                             return(
                                 <Redirector 
                                     key={index}
-                                    redirectorType={element.type}
-                                    redirectorID={element.ID}
+                                    redirectorType='podcast'
+                                    redirectorID={element.podcast_id}
                                 >
                                     <RedirectorInfo>
                                         <RedirectorText
                                             infoType="title"
                                             color="dark"
                                         >
-                                            {element.info.name}
+                                            {element.podcast_title}
                                         </RedirectorText>
                                         <RedirectorText
                                             infoType="user"
                                             color="grey"
                                         >
-                                            {element.info.onwership.username} #{element.info.onwership.userID}
+                                            {element.podcast_author} #{element.podcast_id}
                                         </RedirectorText>  
                                     </RedirectorInfo>
                                     <RedirectorBanner
-                                        url={element.media.bannerURL}
-                                        alt={element.info.name}
+                                        url={`${process.env.REACT_APP_BLOB_HOST}/jpeg/podcast/bg-${element.podcast_id}.jpg`}
+                                        alt={element.podcast_title}
                                         type='podcast'
                                     />
                                 </Redirector >


### PR DESCRIPTION
## Problems  

1. `Podcasts` page still uses the mock-up `API`;
2. `Podcast` page still uses the mock-up `API`.

## Fix

- [x] 1. Introduced back-end based  `API` to the  `Podcasts` at de76cee ;
- [x] 2. Introduced back-end based  `API` to the  `Podcast` at b28c078.